### PR TITLE
Fix history data parsing

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -47,7 +47,10 @@ def _create_history():
 def load_history() -> pd.DataFrame:
     if not HIST_FILE.exists():
         _create_history()
-    return pd.read_csv(HIST_FILE, parse_dates=["date"], index_col="date")
+    df = pd.read_csv(HIST_FILE, parse_dates=["date"], index_col="date")
+    # ensure numeric balance for calculations
+    df["balance"] = pd.to_numeric(df["balance"], errors="coerce")
+    return df
 
 ###############################################################################
 #  Binance helpers


### PR DESCRIPTION
## Summary
- handle string balances in `load_history`

## Testing
- `pip install -r requirements.txt`
- `python app.py` *(fails to run due to missing Streamlit context but no TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_685510df07a883238b80ab4f5f9ccee8