### PR TITLE
Fix history CSV parsing and simplify display

### DIFF
--- a/app.py
+++ b/app.py
@@ -71,11 +71,9 @@ total_aum = total_real + total_virtual
 #  Overview boxes
 ###############################################################################
 st.subheader("Assets under Management")
-col1, col2, col3 = st.columns(3)
+col1 = st.columns(1)[0]
 
 col1.metric("**Total Capital (USD)**", f"${total_aum:,.0f}")
-col2.metric("Real Capital", f"${total_real:,.0f}")
-col3.metric("Virtual Capital", f"${total_virtual:,.0f}")
 
 ###############################################################################
 #  Performance section
@@ -111,9 +109,11 @@ st.line_chart(equity_series.rename("Equity (USD)"))
 st.subheader("LP Accounts")
 inv_df = pd.DataFrame(investors)
 if not inv_df.empty:
-    inv_df_display = inv_df[["name", "balance", "virtual"]].rename(columns={"name": "Investor", "balance": "Balance (USD)", "virtual": "Virtual"})
+    inv_df_display = inv_df[["name", "balance"]].rename(
+        columns={"name": "Investor", "balance": "Balance (USD)"}
+    )
 else:
-    inv_df_display = pd.DataFrame(columns=["Investor", "Balance (USD)", "Virtual"])
+    inv_df_display = pd.DataFrame(columns=["Investor", "Balance (USD)"])
 st.dataframe(inv_df_display, hide_index=True)
 
 ###############################################################################

--- a/utils.py
+++ b/utils.py
@@ -47,13 +47,20 @@ def _create_history():
 def load_history() -> pd.DataFrame:
     if not HIST_FILE.exists():
         _create_history()
-    df = pd.read_csv(HIST_FILE)
+    # History CSV may use commas or tabs as separators depending on how it was
+    # generated.  Use a regex separator via the Python engine so either format
+    # loads correctly.
+    df = pd.read_csv(HIST_FILE, sep=r"[,\t]", engine="python")
+
     # Drop any stray header rows or bad data then parse types
     df = df[df["date"] != "date"]
     df["date"] = pd.to_datetime(df["date"], errors="coerce")
     df["balance"] = pd.to_numeric(df["balance"], errors="coerce")
+
+    # Remove rows with invalid dates or balance values and index by date
     df = df.dropna(subset=["date", "balance"]).set_index("date")
-    return df
+
+    return df.sort_index()
 
 ###############################################################################
 #  Binance helpers


### PR DESCRIPTION
## Summary
- load history data using a regex delimiter so tab-delimited CSVs load correctly
- show only total capital in the overview section
- remove the "Virtual" column from the LP accounts table

## Testing
- `python -m py_compile app.py utils.py`
- `python app.py` *(fails: Streamlit warns about bare mode)*

------
https://chatgpt.com/codex/tasks/task_e_6855221bee0c8323bfcede3f6492270f